### PR TITLE
Allow additional custom config options

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+BACKUP_DIR="/home/docker/backups"
+
 echo "Project: github-backup"
 echo "Author:  lnxd"
 echo "Base:    Alpine 3.9"
@@ -17,12 +19,12 @@ cp /home/docker/github-backup/config/config.json /home/docker/github-backup/conf
 # Update token in config.json match $TOKEN environment variable
 sed -i '/token/c\   \"token\" : \"'${TOKEN}'\",' /home/docker/github-backup/config.json
 
-# Return config.json to persistant volume
-cp /home/docker/github-backup/config.json /home/docker/github-backup/config/config.json
+# Update backup directory to match the containers default
+sed -i '/directory/c\   \"directory\" : \"'${BACKUP_DIR}'\",' /home/docker/github-backup/config.json
 
 # Start backup
 while true
  do python3 github-backup.py /home/docker/github-backup/config/config.json
- chown -R nobody /home/docker/backups
- sleep $SCHEDULE
+ chown -R nobody ${BACKUP_DIR}
+ sleep "$SCHEDULE"
 done


### PR DESCRIPTION
Hello,

For my use case I needed to pass additional config options beyond token and directory.

This change allows a config.json in app data to be used to customize the options.

Token and directory are still taken from docker env variables and will be ignored. This config file only adds additional parameters. 

If no custom config is created, or ignored. This will not change how it currently functions.

To complete this the following would need to be added to the CA plugins xml. I did not see a repo for this.

`
...

\<Volume>
      \<HostDir>/mnt/user/appdata/github-backup/</HostDir>
      \<ContainerDir>/home/docker/github-backup/config/</ContainerDir>
      \<Mode>rw</Mode>
\</Volume>

...

\<Config Name="App data" Target="/home/docker/github-backup/config/" Default="/mnt/user/appdata/github-backup/" Mode="rw" Description="Container Path: /home/docker/github-backup/config/" Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/github-backup/
\</Config>

...
`