### PR TITLE
Change RegEx to allow repository names starting with `.` and `-`

### DIFF
--- a/github-backup.py
+++ b/github-backup.py
@@ -26,7 +26,7 @@ def get_json(url, token):
 
 
 def check_name(name):
-    if not re.match(r"^\w[-\.\w]*$", name):
+    if not re.match(r"^[-\.\w]*$", name):
         raise RuntimeError("invalid name '{0}'".format(name))
     return name
 


### PR DESCRIPTION
Repositry names can start with `-` and `.`, but the current RegEx assumes this is not possible. This causes errors such as:

```
File "github-backup.py", line 92, in main
name = check_name(repo["name"])
File "github-backup.py", line 30, in check_name
raise RuntimeError("invalid name '{0}'".format(name))
RuntimeError: invalid name '.github'
 ```